### PR TITLE
Nexus

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.kutils" name="Utilities for Kodi" version="1.3.0"
+<addon id="script.module.kutils" name="Utilities for Kodi" version="1.3.1"
        provider-name="Philipp Temminghoff (phil65), Frank Feuerbacher (fbacher)">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>

--- a/lib/kutils/listitem.py
+++ b/lib/kutils/listitem.py
@@ -267,6 +267,12 @@ class ListItem:
         props = {k: str(v) for k, v in self._properties.items() if v}
         infos = {k.lower(): v for k, v in self._infos.items() if v}
         infos["path"] = self.path
+        if "media_type" in infos:
+            infos["mediatype"] = infos["media_type"]
+            infos.pop("media_type")
+        if "file" in infos:
+            infos["filenameandpath"] = infos["file"]
+            infos.pop("file")
         if "duration" in infos:
             props['duration(h)'] = utils.format_time(infos["duration"], "h")
             props['duration(m)'] = utils.format_time(infos["duration"], "m")

--- a/lib/kutils/youtube.py
+++ b/lib/kutils/youtube.py
@@ -208,6 +208,8 @@ def search(search_str="", hd="", orderby="relevance", limit=40, extended=True,
               "key" : api_key}
     results = get_data(method="search",
                        params=utils.merge_dicts(params, filters if filters else {}))
+    if 'error' in results.keys():
+        utils.log('youtube get_data ERROR: {error}'.format(error=results.get('error').get('message')))
     if not results or 'items' not in results.keys():
         return None
 	


### PR DESCRIPTION
I made a couple of changes from testing script.extendedinfo in Kodi Nexus

The first is due to changes in Nexus that has deprecated several ListItem class methods for videos.  [https://github.com/xbmc/xbmc/pull/19459](url) The existing code works, but floods the log with "deprecated method" warnings that made it hard to trouble shoot.  My change is to test if Nexus started the script.  If not the existing setters are used.

ListItem.setInfo(dict of info) is deprecated.  
To avoid massive rework I created a global literal that translates the keys from the existing dict into the new InfoTagVideo setter methods and then passes the values as arguments
I didn't find an elegant way to handle ListItem.setCast(list of dict) as instead you have to create Actor objects with the setters using values from each dict.
Finally there are setters for Video/Audio/SubtitleStreamDetail classes.

The second commit is unrelated, but during some testing I found if youtube api returned an error, kutils just returns None to the caller.  So the caller doesn't know why it didn't work.  Ideally there would be a return with the error and let the caller handle it, but I couldn't see any way to do that that would be backward compatible, so I just log the error.  I don't think raising a Kodi notification or other UI related change would be appropriate for a module utility but that's just MHO.